### PR TITLE
[10팀 정태수] Chapter 1-3 React, Beyond the Basics 

### DIFF
--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,21 +1,22 @@
 export function deepEquals(objA: unknown, objB: unknown): boolean {
+
   if (objA === objB) {
     return true;
   }
 
+  // if(typeof objA !== typeof objB) {
+  //   return false;
+  // };
   if (objA === null || objB === null) {
     return false;
   }
 
   if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) return false;
+    
     for (let i = 0; i < objA.length; i++) {
-      if (Array.isArray(objA[i]) || Array.isArray(objB[i])) {
-        return deepEquals(objA[i], objB[i]);
-      } else {
-        if (objA[i] !== objB[i]) {
-          return false;
-        }
-      }
+      //재귀 부분이 제일 헷갈린다. 깊은 비교를 했을때 한번이라도 false가 나온다면 false, 모두 같아야 true여야하기에 for 문 밖에서 return true;
+      if (!deepEquals(objA[i], objB[i])) return false;
     }
     return true;
   }
@@ -33,22 +34,13 @@ export function deepEquals(objA: unknown, objB: unknown): boolean {
     console.log("keysA:", keysA, "keysB:", keysB);
 
     for (const key of keysA) {
-      if (!keysB.includes(key)) {
-        return false;
-      }
-      if (typeof a[key] === "object" && typeof b[key] === "object") {
-        if (!deepEquals(a[key], b[key])) {
-          return false;
-        }
-        return true;
-        //여기가 문제래
-      }
-
+      if (!keysB.includes(key)) return false;
+      if (!deepEquals(a[key], b[key])) return false;
     }
 
     return true;
   }
 
 
-  return objA === objB;
+  return false;
 }

--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,3 +1,54 @@
-export function deepEquals<T>(objA: T, objB: T): boolean {
+export function deepEquals(objA: unknown, objB: unknown): boolean {
+  if (objA === objB) {
+    return true;
+  }
+
+  if (objA === null || objB === null) {
+    return false;
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    for (let i = 0; i < objA.length; i++) {
+      if (Array.isArray(objA[i]) || Array.isArray(objB[i])) {
+        return deepEquals(objA[i], objB[i]);
+      } else {
+        if (objA[i] !== objB[i]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  if (typeof objA === "object" && typeof objB === "object") {
+    console.log("objA:", objA, "objB:", objB);
+    const a = objA as Record<string, unknown>;
+    const b = objB as Record<string, unknown>;
+
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) return false;
+
+    console.log("keysA:", keysA, "keysB:", keysB);
+
+    for (const key of keysA) {
+      if (!keysB.includes(key)) {
+        return false;
+      }
+      if (typeof a[key] === "object" && typeof b[key] === "object") {
+        if (!deepEquals(a[key], b[key])) {
+          return false;
+        }
+        return true;
+        //여기가 문제래
+      }
+
+    }
+
+    return true;
+  }
+
+
   return objA === objB;
 }

--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,5 +1,4 @@
 export function deepEquals(objA: unknown, objB: unknown): boolean {
-
   if (objA === objB) {
     return true;
   }
@@ -13,7 +12,7 @@ export function deepEquals(objA: unknown, objB: unknown): boolean {
 
   if (Array.isArray(objA) && Array.isArray(objB)) {
     if (objA.length !== objB.length) return false;
-    
+
     for (let i = 0; i < objA.length; i++) {
       //재귀 부분이 제일 헷갈린다. 깊은 비교를 했을때 한번이라도 false가 나온다면 false, 모두 같아야 true여야하기에 for 문 밖에서 return true;
       if (!deepEquals(objA[i], objB[i])) return false;
@@ -40,7 +39,6 @@ export function deepEquals(objA: unknown, objB: unknown): boolean {
 
     return true;
   }
-
 
   return false;
 }

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,4 +1,7 @@
-export function shallowEquals<T extends Record<string, unknown>>(objA: T, objB: T): boolean {
+export function shallowEquals<T extends Record<string, unknown>>(
+  objA: T,
+  objB: T,
+): boolean {
   if (objA === objB) {
     console.log("shallowEquals: same reference");
     return true;
@@ -27,7 +30,7 @@ export function shallowEquals<T extends Record<string, unknown>>(objA: T, objB: 
     if (keysA.length !== keysB.length) return false;
     console.log("objA:", objA, objB);
     for (const key of keysA) {
-      if ((objA)[key] !== (objB)[key]) return false;
+      if (objA[key] !== objB[key]) return false;
     }
     return true;
   }

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,8 +1,35 @@
-export function shallowEquals<T>(objA: T, objB: T): boolean {
+export function shallowEquals<T extends Record<string, unknown>>(objA: T, objB: T): boolean {
+  if (objA === objB) {
+    console.log("shallowEquals: same reference");
+    return true;
+  }
 
-  console.log('shallowEquals', objA, objB);
-  if(objA === objB) {
-    console.log('shallowEquals: same reference');
+  if (
+    (typeof objA === "string" && typeof objB === "string") ||
+    (Array.isArray(objA) && Array.isArray(objB))
+  ) {
+    if (objA.length !== objB.length) return false;
+
+    for (let i = 0; i < objA.length; i++) {
+      if (objA[i] !== objB[i]) return false;
+    }
+    return true;
+  }
+
+  if (
+    objA !== null &&
+    objB !== null &&
+    typeof objA === "object" &&
+    typeof objB === "object"
+  ) {
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+    if (keysA.length !== keysB.length) return false;
+    console.log("objA:", objA, objB);
+    for (const key of keysA) {
+      if ((objA)[key] !== (objB)[key]) return false;
+    }
+    return true;
   }
 
   return objA === objB;

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,3 +1,9 @@
 export function shallowEquals<T>(objA: T, objB: T): boolean {
+
+  console.log('shallowEquals', objA, objB);
+  if(objA === objB) {
+    console.log('shallowEquals: same reference');
+  }
+
   return objA === objB;
 }

--- a/src/@lib/hocs/deepMemo.ts
+++ b/src/@lib/hocs/deepMemo.ts
@@ -2,8 +2,8 @@ import { deepEquals } from "../equalities";
 import { ComponentType } from "react";
 import { memo } from "./memo.ts";
 
-export function deepMemo<P extends Record<string, unknown>>(Component: ComponentType<P>) {
-
+export function deepMemo<P extends Record<string, unknown>>(
+  Component: ComponentType<P>,
+) {
   return memo(Component, deepEquals);
-
 }

--- a/src/@lib/hocs/deepMemo.ts
+++ b/src/@lib/hocs/deepMemo.ts
@@ -2,6 +2,8 @@ import { deepEquals } from "../equalities";
 import { ComponentType } from "react";
 import { memo } from "./memo.ts";
 
-export function deepMemo<P extends object>(Component: ComponentType<P>) {
+export function deepMemo<P extends Record<string, unknown>>(Component: ComponentType<P>) {
+
   return memo(Component, deepEquals);
+
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from "react";
 import { shallowEquals } from "../equalities";
 import { ComponentType, useRef } from "react";
@@ -7,17 +6,17 @@ export function memo<P extends Record<string, unknown>>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-
   return function MemoizedComponent(props: P) {
-
     const prevPropsRef = useRef<P | null>(null);
     //prevPropsRef 란 {name: 'kk', age: 10} 과 같은 객체
     const resultRef = useRef<React.ReactElement | null>(null);
     //resultRef란 <div name="23">{name}</div>과 같은 실제 렌더링 결과
-    
-    if( prevPropsRef.current !== null 
-      && _equals(prevPropsRef.current, props) 
-      && resultRef.current !== null ) {
+
+    if (
+      prevPropsRef.current !== null &&
+      _equals(prevPropsRef.current, props) &&
+      resultRef.current !== null
+    ) {
       return resultRef.current;
     }
 
@@ -28,5 +27,5 @@ export function memo<P extends Record<string, unknown>>(
     resultRef.current = result;
     //다음 렌더때 비교하고자 저장
     return result;
-  }
+  };
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,10 +1,32 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import React from "react";
 import { shallowEquals } from "../equalities";
-import { ComponentType } from "react";
+import { ComponentType, useRef } from "react";
 
-export function memo<P extends object>(
+export function memo<P extends Record<string, unknown>>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-  return Component;
+
+  return function MemoizedComponent(props: P) {
+
+    const prevPropsRef = useRef<P | null>(null);
+    //prevPropsRef 란 {name: 'kk', age: 10} 과 같은 객체
+    const resultRef = useRef<React.ReactElement | null>(null);
+    //resultRef란 <div name="23">{name}</div>과 같은 실제 렌더링 결과
+    
+    if( prevPropsRef.current !== null 
+      && _equals(prevPropsRef.current, props) 
+      && resultRef.current !== null ) {
+      return resultRef.current;
+    }
+
+    const result = React.createElement(Component, props);
+
+    prevPropsRef.current = props;
+    //다음 렌더때 비교하고자 저장
+    resultRef.current = result;
+    //다음 렌더때 비교하고자 저장
+    return result;
+  }
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
 import { useMemo } from "./useMemo";
+// import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,
   _deps: DependencyList,
 ) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
+  // return factory as T;
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
 import { useMemo } from "./useMemo";
 // import { useMemo } from "./useMemo";

--- a/src/@lib/hooks/useDeepMemo.ts
+++ b/src/@lib/hooks/useDeepMemo.ts
@@ -5,5 +5,8 @@ import { deepEquals } from "../equalities";
 
 export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
   // 직접 작성한 useMemo를 참고해서 만들어보세요.
+
+  
+
   return useMemo(factory, deps, deepEquals);
 }

--- a/src/@lib/hooks/useDeepMemo.ts
+++ b/src/@lib/hooks/useDeepMemo.ts
@@ -6,7 +6,5 @@ import { deepEquals } from "../equalities";
 export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
   // 직접 작성한 useMemo를 참고해서 만들어보세요.
 
-  
-
   return useMemo(factory, deps, deepEquals);
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
-import { shallowEquals } from "../equalities";
+import { shallowEquals } from "../equalities"; // Updated to accept DependencyList
+import { useRef } from "./useRef";
 
 export function useMemo<T>(
   factory: () => T,
@@ -8,5 +9,21 @@ export function useMemo<T>(
   _equals = shallowEquals,
 ): T {
   // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+
+  const memoized = useRef<{ deps: DependencyList; value: T } | null>(null);
+  //이전 의존성과 결과를 저장할 ref value가 결과
+
+  if (memoized.current && _equals(memoized.current.deps as unknown as Record<string, unknown>, _deps as unknown as Record<string, unknown>)) {
+    //의존성이 변경되지 않은 경우
+    return memoized.current.value;
+  }
+
+  const value = factory();
+  //의존성이 변경된 경우
+  memoized.current = {
+    deps: _deps,
+    value,
+  };
+
+  return value;
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
 import { shallowEquals } from "../equalities"; // Updated to accept DependencyList
 import { useRef } from "./useRef";
@@ -13,7 +12,13 @@ export function useMemo<T>(
   const memoized = useRef<{ deps: DependencyList; value: T } | null>(null);
   //이전 의존성과 결과를 저장할 ref value가 결과
 
-  if (memoized.current && _equals(memoized.current.deps as unknown as Record<string, unknown>, _deps as unknown as Record<string, unknown>)) {
+  if (
+    memoized.current &&
+    _equals(
+      memoized.current.deps as unknown as Record<string, unknown>,
+      _deps as unknown as Record<string, unknown>,
+    )
+  ) {
     //의존성이 변경되지 않은 경우
     return memoized.current.value;
   }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,7 +1,11 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
   // React의 useState를 이용해서 만들어보세요.
 
-  
+  const [ref] = useState({ current: initialValue });
 
-  return { current: initialValue };
+  return ref;
+
+  // return { current: initialValue };
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,4 +1,7 @@
 export function useRef<T>(initialValue: T): { current: T } {
   // React의 useState를 이용해서 만들어보세요.
+
+  
+
   return { current: initialValue };
 }

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,0 +1,131 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface Notification {
+  id: number;
+  message: string;
+  type: "info" | "success" | "warning" | "error";
+}
+
+const NotificationContext = createContext<
+  | {
+      notifications: Notification[];
+      addNotification: (message: string, type: Notification["type"]) => void;
+      removeNotification: (id: number) => void;
+    }
+  | undefined
+>(undefined);
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const addNotification = useCallback(
+    (message: string, type: Notification["type"]) => {
+      //함수에 useCallback 해야되네
+      const newNotification: Notification = {
+        id: Date.now(),
+        message,
+        type,
+      };
+      setNotifications((prev) => [...prev, newNotification]);
+    },
+    [],
+  );
+
+  const removeNotification = useCallback((id: number) => {
+    //함수에 useCallback 해야되네
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      addNotification,
+      removeNotification,
+    }),
+    [notifications, addNotification, removeNotification],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotification = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx)
+    throw new Error("useNotification must be used within NotificationProvider");
+  return ctx;
+};
+
+// import { createContext, PropsWithChildren, useContext, useState } from "react";
+// import { useCallback, useMemo } from "../@lib";
+// import { Notification } from "../App";
+
+// interface NotificationContextType {
+//   notifications: Notification[];
+//   addNotification: (message: string, type: Notification["type"]) => void;
+//   removeNotification: (id: number) => void;
+// }
+
+// const NotificationContext = createContext<NotificationContextType | undefined>(
+//   undefined,
+// );
+
+// export const NotificationProvider: React.FC<PropsWithChildren> = ({
+//   children,
+// }) => {
+//   const [notifications, setNotifications] = useState<Notification[]>([]);
+
+//   const addNotification = useCallback(
+//     (message: string, type: Notification["type"]) => {
+//       const newNotification: Notification = {
+//         id: Date.now(),
+//         message,
+//         type,
+//       };
+//       setNotifications((prev) => [...prev, newNotification]);
+//     },
+//     [],
+//   );
+
+//   const removeNotification = useCallback((id: number) => {
+//     setNotifications((prev) =>
+//       prev.filter((notification) => notification.id !== id),
+//     );
+//   }, []);
+
+//   const contextValue: NotificationContextType = useMemo(
+//     () => ({
+//       notifications,
+//       addNotification,
+//       removeNotification,
+//     }),
+//     [addNotification, notifications, removeNotification],
+//   );
+
+//   return (
+//     <NotificationContext.Provider value={contextValue}>
+//       {children}
+//     </NotificationContext.Provider>
+//   );
+// };
+
+// export function useNotification() {
+//   const context = useContext(NotificationContext);
+//   if (context === undefined) {
+//     throw new Error(
+//       "useNotificationContext must be used within an NotificationProvider",
+//     );
+//   }
+//   return context;
+// }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useMemo, useState } from "react";
+
+const ThemeContext = createContext<
+  | {
+      theme: string;
+      toggleTheme: () => void;
+    }
+  | undefined
+>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState("light");
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+};

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,117 @@
+// import { createContext, useContext, useMemo, useState } from "react";
+
+// interface User {
+//   id: number;
+//   name: string;
+//   email: string;
+// }
+
+// const UserContext = createContext<{
+//   user: User | null;
+//   login: (email: string, password: string) => void;
+//   logout: () => void;
+// } | undefined>(undefined);
+
+// export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+//   const [user, setUser] = useState<User | null>(null);
+//   // const { addNotification } = useNotification(); // ✅ 여기서 사용
+
+//   const login = (email: string, password: string) => {
+//     setUser({ id: 1, name: "홍길동", email });
+//     // addNotification("로그인 성공", "success");
+//   };
+
+//   const logout = () => {
+//     setUser(null)
+//     // addNotification("로그아웃", "success");
+//   };
+
+//   const value = useMemo(() => ({ user, login, logout }), [user, login, logout]);
+
+//   return (
+//     <UserContext.Provider value={value}>
+//       {children}
+//     </UserContext.Provider>
+//   );
+// };
+
+// export const useUser = () => {
+//   const ctx = useContext(UserContext);
+//   if (!ctx) throw new Error("useUser must be used within UserProvider");
+//   return ctx;
+// };
+
+import { createContext, PropsWithChildren, useContext, useState } from "react";
+import { useCallback, useMemo } from "../@lib";
+import { User } from "../App";
+import { useNotification } from "./NotificationContext";
+
+interface UserContextType {
+  user: User | null;
+  login: (email: string, password: string) => void;
+  logout: () => void;
+  check: () => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const { addNotification } = useNotification();
+  //여기서 notification을 안쓰려고 했던이유는 notification에 변형이 생기면 userProvider도 변형이 생기고, 그러면 user를 사용하는 header도 불필요한
+  //렌더링이 일어났었기 때문임. 그런데 useCallback과 useMemo로 안생기게 되는것 같다.
+  //useCallback 안쓴 check 함수가 있는것만으로도 알림추가시 header까지 렌더링이 일어난다.
+
+  // userConext가 실행되겠지? 그러면 check 함수도 어쨋든 무조건 생성될거고.
+  // 새롭게 생성된다는건 렌더링을 의미하는거고 notification 알림을 닫는데도
+  // header가 렌더링되는건 userContext안에 notification을 사용하고 있기때문이야.
+
+  //로그인할때 addNotification 까지.
+  //   const login =
+  //     (email: string) => {
+  //   setUser({ id: 1, name: "홍길동", email });
+  //   addNotification("로그인 성공", "success");
+  // };
+
+  const check = useCallback(() => {
+    setUser({ id: 1, name: "빵야", email: "빵야@naver.com" });
+    // addNotification 렌더링이 일어나지 않는다.
+  }, []);
+
+  const login = useCallback(
+    //여기도 useCallback 써야하네
+    (email: string) => {
+      setUser({ id: 1, name: "홍길동", email });
+      addNotification("성공적으로 로그인되었습니다", "success");
+    },
+    [addNotification],
+  );
+
+  const logout = useCallback(() => {
+    setUser(null);
+    addNotification("로그아웃되었습니다", "info");
+  }, [addNotification]);
+
+  const contextValue: UserContextType = useMemo(
+    //메모가 직격탄이네
+    () => ({
+      user,
+      login,
+      logout,
+      check,
+    }),
+    [login, logout, user, check],
+  );
+
+  return (
+    <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>
+  );
+};
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useUserContext must be used within an UserProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-5th-chapter1-1/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료
- [x] memo 구현 완료
- [x] deepMemo 구현 완료
- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useCallback 구현 완료

### 심화 과제

- [x] 기본과제에서 작성한 hook을 이용하여 렌더링 최적화를 진행하였다.
- [x] Context 코드를 개선하여 렌더링을 최소화하였다.

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

shallowEquals
객체와 배열의 1단계만 비교해서 값이 같은지 판단
-> 중첩구조는 사용 불가능

key 갯수와 key의 값이 같은지 비교한다.

deepEquals
중첩구조까지 재귀함수로 비교한다.
deepEquals는 연산량이 많으므로 비교해서 얻는 최적화 효과 vs 최적화 비용을 고려하여 개발자가 적절히 사용해야 한다.

HOC (고차원 컴포넌트 High Order Component)
3-1. memo
memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 리렌더링을 방지합니다.

3-2. deepMemo
memo에서 이전ref와 현 ref를 비교할때 deepEquals를 비교하는 차이

useRef
useState로 첫 초기화값을 저장한다. useRef는 단순히 { current: 값 } 객체를 반환하지만,

핵심은 React가 리렌더링을 해도 이 값이 초기화되지 않고 유지된다는 것이에요.

setState()처럼 react에게 알리고 바꾸는게 아니라
ref.current = 1; 이렇게 바꾸기 때문에 react가 추적못함.

const mouseXRef = useRef(0);

const handleMouseMove = (e: MouseEvent) => {
  mouseXRef.current = e.clientX;
};
스크롤/마우스 위치는 실시간으로 변하기 때문에 setState하면 리렌더링 폭발😱

useRef를 쓰면 렌더링 없이 값만 잘 쌓아둘 수 있어요.
useMemo
(학습단계에서는 useMemo가 어떻게 작동하는지에 대해 학습하기위해 shallowEquals를 사용했지만 실제 react에서는 참조비교만을 실행한ㄷ.)

useMemo(() => {
return calculate();
}, [obj]);
여기서 obj가 매번 새롭게 { a: 1 }처럼 만들어지면
→ obj !== obj 이기 때문에 useMemo는 매번 다시 실행.

useMemo는 그냥 deps의 참조값만 보고 판단. (===)



질문이 하나 있는데요!!

실제 리액트 useMemo 공식 동작에서도 리렌더링 조건은 === 일치 연산자에 대해서만 이루어진다고 합니다.
즉 shallowEqauls 도 실행하지않고 참조비교만 실행한다고 하는데요!
그런데 이번 과제에서 shallowEquals와 deepEquals를 구현한 목적이 있을까요?