### PR TITLE
[11팀 김진관] Chapter 1-3. React,  Beyond the Basics

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,34 @@
+name: GitHub Pages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Build
+        run: |
+          pnpm install
+          pnpm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,3 +1,28 @@
+import { isObject } from "../../utils/types";
+
 export function deepEquals<T>(objA: T, objB: T): boolean {
-  return objA === objB;
+  if (objA === objB) {
+    return true;
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) {
+      return false;
+    }
+
+    return objA.every((value, index) => deepEquals(value, objB[index]));
+  }
+
+  if (isObject(objA) && isObject(objB)) {
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    return keysA.every((key) => deepEquals(objA[key], objB[key]));
+  }
+
+  return false;
 }

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,3 +1,28 @@
+import { isObject } from "../../utils/types";
+
 export function shallowEquals<T>(objA: T, objB: T): boolean {
-  return objA === objB;
+  if (objA === objB) {
+    return true;
+  }
+
+  if (isObject(objA) && isObject(objB)) {
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    return keysA.every((key) => objA[key] === objB[key]);
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) {
+      return false;
+    }
+
+    return objA.every((value, index) => value === objB[index]);
+  }
+
+  return false;
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -4,9 +4,9 @@ import { shallowEquals } from "../equalities";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
-  _equals = shallowEquals,
+  _equals = shallowEquals
 ) {
-  const memoized: Array<{ props: P; component: JSX.Element }> = [];
+  const memoized: Array<{ props: P; component: React.ReactElement }> = [];
 
   return (props: P) => {
     const found = memoized.find((item) => _equals(item.props, props));

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,10 +1,23 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { ComponentType, createElement } from "react";
+
 import { shallowEquals } from "../equalities";
-import { ComponentType } from "react";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
-  _equals = shallowEquals,
+  _equals = shallowEquals
 ) {
-  return Component;
+  const memoized: Array<{ props: P; component: JSX.Element }> = [];
+
+  return (props: P) => {
+    const found = memoized.find((item) => _equals(item.props, props));
+    if (found) {
+      return found.component;
+    }
+
+    const component = createElement(Component, props);
+
+    memoized.push({ props, component });
+
+    return component;
+  };
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -6,16 +6,20 @@ export function memo<P extends object>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-  let memoized: { props: P; element: React.ReactElement } | null = null;
+  let memoized: [React.ReactElement, P] | [undefined, undefined] = [
+    undefined,
+    undefined,
+  ];
 
   return (props: P) => {
-    if (memoized && _equals(memoized.props, props)) {
-      return memoized.element;
+    const [prevElement, prevProps] = memoized;
+    if (prevProps && _equals(prevProps, props)) {
+      return prevElement;
     }
 
     const element = createElement(Component, props);
 
-    memoized = { props, element };
+    memoized = [element, props];
 
     return element;
   };

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -4,7 +4,7 @@ import { shallowEquals } from "../equalities";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
-  _equals = shallowEquals
+  _equals = shallowEquals,
 ) {
   const memoized: Array<{ props: P; component: React.ReactElement }> = [];
 

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -4,7 +4,7 @@ import { shallowEquals } from "../equalities";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
-  _equals = shallowEquals
+  _equals = shallowEquals,
 ) {
   const memoized: Array<{ props: P; component: JSX.Element }> = [];
 

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -6,18 +6,17 @@ export function memo<P extends object>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-  const memoized: Array<{ props: P; component: React.ReactElement }> = [];
+  let memoized: { props: P; element: React.ReactElement } | null = null;
 
   return (props: P) => {
-    const found = memoized.find((item) => _equals(item.props, props));
-    if (found) {
-      return found.component;
+    if (memoized && _equals(memoized.props, props)) {
+      return memoized.element;
     }
 
-    const component = createElement(Component, props);
+    const element = createElement(Component, props);
 
-    memoized.push({ props, component });
+    memoized = { props, element };
 
-    return component;
+    return element;
   };
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,11 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
 
 import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,
-  _deps: DependencyList
+  _deps: DependencyList,
 ) {
   const fn = useMemo(() => factory, _deps);
   return fn;

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
 
+import { useMemo } from "./useMemo";
+
 export function useCallback<T extends Function>(
   factory: T,
-  _deps: DependencyList,
+  _deps: DependencyList
 ) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  const fn = useMemo(() => factory, _deps);
+  return fn;
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -6,7 +6,7 @@ import { useRef } from "./useRef";
 export function useMemo<T>(
   factory: () => T,
   _deps: DependencyList,
-  _equals = shallowEquals
+  _equals = shallowEquals,
 ): T {
   const memoized = useRef<{ deps: DependencyList; result: T }[]>([]);
 

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -8,15 +8,18 @@ export function useMemo<T>(
   _deps: DependencyList,
   _equals = shallowEquals,
 ): T {
-  const memoized = useRef<{ deps: DependencyList; result: T } | null>(null);
+  const memoized = useRef<[T, DependencyList] | [undefined, undefined]>([
+    undefined,
+    undefined,
+  ]);
 
-  if (memoized.current && _equals(memoized.current.deps, _deps)) {
-    return memoized.current.result;
+  const [prevValue, prevDeps] = memoized.current;
+
+  if (prevDeps && _equals(prevDeps, _deps)) {
+    return prevValue;
   }
 
-  const result = factory();
-
-  memoized.current = { deps: _deps, result };
-
-  return result;
+  const nextValue = factory();
+  memoized.current = [nextValue, _deps];
+  return nextValue;
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,12 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
+
 import { shallowEquals } from "../equalities";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(
   factory: () => T,
   _deps: DependencyList,
-  _equals = shallowEquals,
+  _equals = shallowEquals
 ): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const memoized = useRef<{ deps: DependencyList; result: T }[]>([]);
+
+  const found = memoized.current.find((item) => _equals(item.deps, _deps));
+
+  if (found) {
+    return found.result;
+  }
+
+  const result = factory();
+
+  memoized.current.push({ deps: _deps, result });
+
+  return result;
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -8,17 +8,15 @@ export function useMemo<T>(
   _deps: DependencyList,
   _equals = shallowEquals,
 ): T {
-  const memoized = useRef<{ deps: DependencyList; result: T }[]>([]);
+  const memoized = useRef<{ deps: DependencyList; result: T } | null>(null);
 
-  const found = memoized.current.find((item) => _equals(item.deps, _deps));
-
-  if (found) {
-    return found.result;
+  if (memoized.current && _equals(memoized.current.deps, _deps)) {
+    return memoized.current.result;
   }
 
   const result = factory();
 
-  memoized.current.push({ deps: _deps, result });
+  memoized.current = { deps: _deps, result };
 
   return result;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,4 +1,8 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
   // React의 useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [state] = useState({ current: initialValue });
+
+  return state;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
 export function useRef<T>(initialValue: T): { current: T } {
-  // React의 useState를 이용해서 만들어보세요.
   const [state] = useState({ current: initialValue });
 
   return state;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ interface NotificationContextValue {
 }
 
 const NotificationContext = createContext<NotificationContextValue | undefined>(
-  undefined
+  undefined,
 );
 
 const NotificationProvider: React.FC<PropsWithChildren> = ({ children }) => {
@@ -70,11 +70,11 @@ const NotificationProvider: React.FC<PropsWithChildren> = ({ children }) => {
       };
       setNotifications((prev) => [...prev, newNotification]);
     },
-    []
+    [],
   );
   const removeNotification = useCallback((id: number) => {
     setNotifications((prev) =>
-      prev.filter((notification) => notification.id !== id)
+      prev.filter((notification) => notification.id !== id),
     );
   }, []);
 
@@ -95,7 +95,7 @@ const useNotificationContext = () => {
   const context = useContext(NotificationContext);
   if (context === undefined) {
     throw new Error(
-      "useNotificationContext must be used within a NotificationProvider"
+      "useNotificationContext must be used within a NotificationProvider",
     );
   }
   return context;
@@ -118,7 +118,7 @@ const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
       setUser({ id: 1, name: "홍길동", email });
       addNotification("성공적으로 로그인되었습니다", "success");
     },
-    [addNotification]
+    [addNotification],
   );
 
   const logout = useCallback(() => {
@@ -203,7 +203,7 @@ export const ItemList: React.FC<{
   const filteredItems = items.filter(
     (item) =>
       item.name.toLowerCase().includes(filter.toLowerCase()) ||
-      item.category.toLowerCase().includes(filter.toLowerCase())
+      item.category.toLowerCase().includes(filter.toLowerCase()),
   );
 
   const totalPrice = filteredItems.reduce((sum, item) => sum + item.price, 0);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import React, {
 } from "react";
 
 import { generateItems, renderLog } from "./utils";
-import { useCallback, memo } from "./@lib";
+import { useCallback, useMemo } from "./@lib";
 import { ThemeProvider, useThemeContext } from "./context/ThemeContext";
 import BaseLayout from "./components/BaseLayout";
 // 타입 정의
@@ -58,11 +58,14 @@ const NotificationProvider: React.FC<PropsWithChildren> = ({ children }) => {
     );
   }, []);
 
-  const contextValue: NotificationContextValue = {
-    notifications,
-    addNotification,
-    removeNotification,
-  };
+  const contextValue: NotificationContextValue = useMemo(
+    () => ({
+      notifications,
+      addNotification,
+      removeNotification,
+    }),
+    [notifications, addNotification, removeNotification],
+  );
 
   return (
     <NotificationContext.Provider value={contextValue}>
@@ -106,11 +109,14 @@ const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
     addNotification("로그아웃되었습니다", "info");
   }, [addNotification]);
 
-  const contextValue: UserContextValue = {
-    user,
-    login,
-    logout,
-  };
+  const contextValue: UserContextValue = useMemo(
+    () => ({
+      user,
+      login,
+      logout,
+    }),
+    [user, login, logout],
+  );
 
   return (
     <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>
@@ -126,7 +132,7 @@ const useUserContext = () => {
 };
 
 // Header 컴포넌트
-export const Header: React.FC = memo(() => {
+export const Header: React.FC = () => {
   renderLog("Header rendered");
   const { theme, toggleTheme } = useThemeContext();
   const { user, login, logout } = useUserContext();
@@ -169,13 +175,13 @@ export const Header: React.FC = memo(() => {
       </div>
     </header>
   );
-});
+};
 
 // ItemList 컴포넌트
 export const ItemList: React.FC<{
   items: Item[];
   onAddItemsClick: () => void;
-}> = memo(({ items, onAddItemsClick }) => {
+}> = ({ items, onAddItemsClick }) => {
   renderLog("ItemList rendered");
   const [filter, setFilter] = useState("");
   const { theme } = useThemeContext();
@@ -228,10 +234,10 @@ export const ItemList: React.FC<{
       </ul>
     </div>
   );
-});
+};
 
 // ComplexForm 컴포넌트
-export const ComplexForm: React.FC = memo(() => {
+export const ComplexForm: React.FC = () => {
   renderLog("ComplexForm rendered");
   const { addNotification } = useNotificationContext();
   const [formData, setFormData] = useState({
@@ -313,10 +319,10 @@ export const ComplexForm: React.FC = memo(() => {
       </form>
     </div>
   );
-});
+};
 
 // NotificationSystem 컴포넌트
-export const NotificationSystem: React.FC = memo(() => {
+export const NotificationSystem: React.FC = () => {
   renderLog("NotificationSystem rendered");
   const { notifications, removeNotification } = useNotificationContext();
 
@@ -346,7 +352,7 @@ export const NotificationSystem: React.FC = memo(() => {
       ))}
     </div>
   );
-});
+};
 
 // 메인 App 컴포넌트
 const App: React.FC = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,11 @@ import React, {
   useContext,
   PropsWithChildren,
 } from "react";
+
 import { generateItems, renderLog } from "./utils";
 import { useCallback, memo } from "./@lib";
+import { ThemeProvider, useThemeContext } from "./context/ThemeContext";
+import BaseLayout from "./components/BaseLayout";
 // 타입 정의
 interface Item {
   id: number;
@@ -25,29 +28,6 @@ interface Notification {
   message: string;
   type: "info" | "success" | "warning" | "error";
 }
-
-interface ThemeContextValue {
-  theme: string;
-  toggleTheme: () => void;
-}
-
-const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
-
-const ThemeProvider: React.FC<
-  PropsWithChildren<{ value: ThemeContextValue }>
-> = ({ children, value }) => {
-  return (
-    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
-  );
-};
-
-const useThemeContext = () => {
-  const context = useContext(ThemeContext);
-  if (context === undefined) {
-    throw new Error("useThemeContext must be used within a ThemeProvider");
-  }
-  return context;
-};
 
 interface NotificationContextValue {
   notifications: Notification[];
@@ -370,12 +350,7 @@ export const NotificationSystem: React.FC = memo(() => {
 
 // 메인 App 컴포넌트
 const App: React.FC = () => {
-  const [theme, setTheme] = useState("light");
   const [items, setItems] = useState(generateItems(1000));
-
-  const toggleTheme = useCallback(() => {
-    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
-  }, []);
 
   const addItems = useCallback(() => {
     setItems((prevItems) => [
@@ -384,18 +359,11 @@ const App: React.FC = () => {
     ]);
   }, []);
 
-  const themeValue: ThemeContextValue = {
-    theme,
-    toggleTheme,
-  };
-
   return (
-    <ThemeProvider value={themeValue}>
+    <ThemeProvider>
       <NotificationProvider>
         <UserProvider>
-          <div
-            className={`min-h-screen ${theme === "light" ? "bg-gray-100" : "bg-gray-900 text-white"}`}
-          >
+          <BaseLayout>
             <Header />
             <div className="container mx-auto px-4 py-8">
               <div className="flex flex-col md:flex-row">
@@ -408,7 +376,7 @@ const App: React.FC = () => {
               </div>
             </div>
             <NotificationSystem />
-          </div>
+          </BaseLayout>
         </UserProvider>
       </NotificationProvider>
     </ThemeProvider>

--- a/src/components/BaseLayout.tsx
+++ b/src/components/BaseLayout.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from "react";
+
+import { memo } from "../@lib";
+import { useThemeContext } from "../context/ThemeContext";
+
+const BaseLayout: React.FC<PropsWithChildren> = ({ children }) => {
+  const { theme } = useThemeContext();
+
+  return (
+    <div
+      className={`min-h-screen ${theme === "light" ? "bg-gray-100" : "bg-gray-900 text-white"}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default memo(BaseLayout);

--- a/src/context/ThemeContext/ThemeContext.ts
+++ b/src/context/ThemeContext/ThemeContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+export interface ThemeContextValue {
+  theme: string;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(
+  undefined,
+);

--- a/src/context/ThemeContext/ThemeProvider.tsx
+++ b/src/context/ThemeContext/ThemeProvider.tsx
@@ -1,0 +1,20 @@
+import React, { useState, PropsWithChildren } from "react";
+import { useCallback } from "../../@lib";
+import { ThemeContext } from "./ThemeContext";
+
+export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [theme, setTheme] = useState("light");
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  }, []);
+
+  const value = {
+    theme,
+    toggleTheme,
+  };
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+};

--- a/src/context/ThemeContext/index.ts
+++ b/src/context/ThemeContext/index.ts
@@ -1,0 +1,2 @@
+export * from "./ThemeProvider";
+export * from "./useThemeContext";

--- a/src/context/ThemeContext/useThemeContext.ts
+++ b/src/context/ThemeContext/useThemeContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { ThemeContext } from "./ThemeContext";
+
+export const useThemeContext = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react-swc";
 export default mergeConfig(
   defineConfig({
     plugins: [react()],
+    base: "./",
   }),
   defineTestConfig({
     test: {


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

https://kkole3897.github.io/front_5th_chapter1-3/

### 기본과제

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료
- [x] memo 구현 완료
- [x] deepMemo 구현 완료
- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useCallback 구현 완료

### 심화 과제

- [x] 기본과제에서 작성한 hook을 이용하여 렌더링 최적화를 진행하였다.
- [x] Context 코드를 개선하여 렌더링을 최소화하였다.

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장
<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->
useMemo, useCallback, memo를 렌더링 최적화를 위해 사용해야하는 건 알았는데, 적절하게 사용하지 못한 경우가 많았습니다. 개인적으로 사이드 프로젝트에서만 리액트를 사용했던터라 사용할 일이 극히 드물었는데 이번 과제에서 직접 구현해나가면서 각각에 대한 사용법을 확실하게 익힐 수 있었습니다.

### 코드 품질
<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->
컴포넌트를 분리해야되는 부분 이외에는 크게 리팩토링이 필요한 부분은 없습니다.

만족스러웠던 부분은 렌더링 최적화를 두가지 방식으로 해결했다는 점입니다(feature/app-memo 브랜치에 다른 방식으로 최적화 구현함). 처음에는 useMemo, useCallback의 사용은 감을 잡았는데 memo에 대해서는 감을 덜 잡은 상태였습니다. 그래서 App 컴포넌트에서 theme 상태를 갖고 있는 상황에서 theme가 변경되면 하위의 모든 컴포넌트들이 모두 리렌더링되는 것을 막을 수 없어보였습니다. 그래서 App 컴포넌트에서 theme를 사용하는 부분을 다른 컴포넌트로 분리해서 theme 상태를 App에서 없애는 방식을 택했습니다. 이렇게 하니까 App이 리렌더링되는 상황이 사라져서 심화과제 테스트 케이스를 모두 통과할 수 있었습니다.
하지만 이렇게 하면 memo를 사용하는 이유가 전혀 없어질 거라는 생각이 들었습니다. 구현했을 때 memo에 대한 이해도가 낮아서 모든 컴포넌트를 memo로 감쌌었는데, 실험삼아 모든 memo를 뺐는데도 문제가 없었습니다. 이 때 여러가지 시도를 하면서 memo의 동작 방식을 이전보다 확실하게 이해할 수 있었습니다. memo는 props의 변화가 없으면 이전 컴포넌트를 그대로 렌더링하는데 지금 있는 컴포넌트들은 props를 전달하는 방식이 하나도 없고 부모에서도 리렌더링이 일어날 일이 없으니 memo가 있으나 없으나 동일했던 것이었습니다. 억지로 props를 넣을 상황은 아닌 듯 해서 memo, useMemo에 대한 동작을 더 잘 이해해보고자 theme 상태는 App에서 만들어서 ThemeProvider로 필요한 context 값을 넘겨주는 방식으로 렌더링 최적화를 진행해봤습니다. theme를 App에서 갖고 있으니까 Header에서 toggleTheme를 호출했을 때 App이 리렌더링되는 것을 확인할 수 있었고, 테스트도 실패했습니다. 이미 개별 컴포넌트들에서 전달 받은 context 상태와 handler들은 useMemo와 useCallback으로 값이 변하지 않으면 재평가되지 않아서 리렌더링이 불필요하게 일어나는 상황은 아니었습니다. 보니까 App이 리렌더링되면서 초기 generateItems를 호출하는 부분이 한번 더 실행되는 문제였어서, 초기 items를 useMemo로 다시 실행되지 않도록 막으면서 테스트를 통과할 수 있었습니다.
지금 생각해보면 되게 별거 없는 차이었지만 이해도의 차이로 인해서 여러 시행착오를 겪었습니다. 그래도 이번 기회에 useMemo, useCallback, memo를 확실하게 이해할 수 있었고, React를 오랜만에 쓰더라도 렌더링 최적화에 대한 거부감은 확실히 없을 것 같습니다.

### 학습 효과 분석
<!-- 예시
- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->
useMemo를 구현할 때 처음에는 이전 상태와 deps들을 모두 기록해두는 방식으로 구현했었습니다. 그런데 프로젝트가 커지고 많은 부분에서 useMemo를 사용하면 메모리가 부족해지지 않을까라는 의문이 들었습니다. 그래서 이전 상태하고만 비교하는 방식으로 변경했습니다. 변경하고 나서 생각해보니까 리액트는 어떻게 구현하고 있을지 궁금했습니다. 그래서 직접 리액트 코드를 분석해보기로 했습니다. useMemo를 export하는 부분이 `packages/react/src/ReactHooks` 쪽에 있었는데 도저히 실제 구현 부분을 찾기가 힘들었습니다. 클로드의 도움을 받아 `packages/react-reconciler/src/ReactFiberHooks` 쪽에 있는걸 확인할 수 있었습니다.
기본적인 개념 자체는 과제와 거의 유사했고, 차이라고 하면 mount와 update를 분리해서 사용하고 있다는 점과 직접적으로 equals 함수를 전달하고 있지 않다는 점이었습니다.
React와 유사하게 구현해보고 React 실제 코드와 비교해보니까 이해하기가 훨씬 수월했습니다. 예전에도 React 코드를 분석해보고 싶은 생각이 들었는데 너무 방대해서 금새 포기하는 경우가 있었는데 ai 도움을 받으면 가능할거라는 생각이 들었습니다.

### 과제 피드백
<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->
간결하게 hook에 대해 구현했지만 hook에 대한 이해는 그 간결함보다 훨씬 깊어져서 좋았습니다.

## 리뷰 받고 싶은 내용

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 요청의 예시)
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 요청의 예시)
- 현재 함수와 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수를 더 명확하게 이름 지을 수 있는 방법에 대해 조언해주실 수 있나요?
- 현재 파일 단위로 코드가 분리되어 있지만, 모듈화나 계층화가 부족한 것 같습니다. 어떤 기준으로 클래스를 분리하거나 모듈화를 진행하면 유지보수에 도움이 될까요?
- MVC 패턴을 따르려고 했는데, 제가 구현한 구조가 MVC 원칙에 맞게 잘 구성되었는지 검토해주시고, 보완할 부분을 제안해주실 수 있을까요?
- 컴포넌트 간의 의존성이 높아져서 테스트하기 어려운 상황입니다. 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?
-->

useMemo에서 type 추론을 위해서 초기 memoized를 [undefined, undefined] 형태로 저장했는데 좀 더 자연스럽게 타입 추론을 할 수 있는 방법이 있을까요?