### PR TITLE
[13팀 최서은] Chapter 1-3 React, Beyond the Basics

### DIFF
--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -35,6 +35,7 @@ export function deepEquals(objA: any, objB: any): boolean {
 
   //    - 재귀적으로 각 속성에 대해 deepEquals 호출
   return objAKeys.every(
+    // eslint-disable-next-line no-prototype-builtins
     (key) => objB.hasOwnProperty(key) && deepEquals(objA[key], objB[key]),
   );
 }

--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,4 +1,4 @@
-export function deepEquals(objA: any, objB: any): boolean {
+export function deepEquals(objA: unknown, objB: unknown): boolean {
   // 1. 기본 타입이거나 null인 경우 처리
   if (Object.is(objA, objB)) {
     return true;
@@ -21,7 +21,7 @@ export function deepEquals(objA: any, objB: any): boolean {
   }
   if (isArrayA && isArrayB) {
     if (objA.length !== objB.length) return false;
-    return objA.every((item: any, index: number) =>
+    return objA.every((item: unknown, index: number) =>
       deepEquals(item, objB[index]),
     );
   }

--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,3 +1,40 @@
-export function deepEquals<T>(objA: T, objB: T): boolean {
-  return objA === objB;
+export function deepEquals(objA: any, objB: any): boolean {
+  // 1. 기본 타입이거나 null인 경우 처리
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (objA === null || objB === null) {
+    return false;
+  }
+
+  if (typeof objA !== "object" || typeof objB !== "object") {
+    return false;
+  }
+
+  // 2. 둘 다 객체인 경우:
+  //    - 배열인지 확인
+  const isArrayA = Array.isArray(objA);
+  const isArrayB = Array.isArray(objB);
+  if (isArrayA !== isArrayB) {
+    return false;
+  }
+  if (isArrayA && isArrayB) {
+    if (objA.length !== objB.length) return false;
+    return objA.every((item: any, index: number) =>
+      deepEquals(item, objB[index]),
+    );
+  }
+
+  //    - 객체의 키 개수가 다른 경우 처리
+  const objAKeys = Object.keys(objA);
+  const objBKeys = Object.keys(objB);
+  if (objAKeys.length !== objBKeys.length) {
+    return false;
+  }
+
+  //    - 재귀적으로 각 속성에 대해 deepEquals 호출
+  return objAKeys.every(
+    (key) => objB.hasOwnProperty(key) && deepEquals(objA[key], objB[key]),
+  );
 }

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,3 +1,39 @@
 export function shallowEquals<T>(objA: T, objB: T): boolean {
-  return objA === objB;
+  // 1. 완전 동일한 값인지 비교
+  if (objA === objB) {
+    return true;
+  }
+
+  // 2. null인지 체크
+  if (objA === null || objB === null) {
+    return false;
+  }
+
+  // 3. 타입 체크(원시값은 객체 비교 의미가 없음)
+  if (typeof objA !== "object" || typeof objB !== "object") {
+    return false;
+  }
+
+  // 4. 배열인지 체크
+  if (Array.isArray(objA) !== Array.isArray(objB)) {
+    return false;
+  }
+
+  // 5. 객체 비교
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  if (!isObject(objA) || !isObject(objB)) {
+    return false;
+  }
+
+  return keysA.every((key) => Object.is(objA[key], objB[key]));
+}
+
+function isObject(target: unknown) {
+  return typeof target === "object";
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,10 +1,28 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { shallowEquals } from "../equalities";
+import { ReactElement } from "react";
 import { ComponentType } from "react";
+import { useRef } from "../hooks";
+import React from "react";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-  return Component;
+  const MemoizedComponent = (props: P): JSX.Element => {
+    const prevPropsRef = useRef<P | null>(null);
+    const prevElementRef = useRef<ReactElement | null>(null);
+
+    // 첫 렌더거나 props가 변경되었을 때
+    if (
+      prevPropsRef.current === null ||
+      !_equals(prevPropsRef.current, props)
+    ) {
+      prevPropsRef.current = props;
+      prevElementRef.current = React.createElement(Component, props);
+    }
+
+    return prevElementRef.current as JSX.Element;
+  };
+
+  return MemoizedComponent;
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,
   _deps: DependencyList,
 ) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -7,5 +7,6 @@ export function useCallback<T extends Function>(
   _deps: DependencyList,
 ) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useMemo(() => factory, _deps);
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,12 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
 import { shallowEquals } from "../equalities";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(
   factory: () => T,
   _deps: DependencyList,
   _equals = shallowEquals,
 ): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const memoRef = useRef<{
+    deps: DependencyList;
+    value: T;
+  } | null>(null);
+
+  if (memoRef.current === null || !_equals(memoRef.current.deps, _deps)) {
+    // 의존성이 처음이거나 바뀐 경우: 계산하고 저장
+    memoRef.current = {
+      deps: _deps,
+      value: factory(),
+    };
+  }
+
+  return memoRef.current.value;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,4 +1,9 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // React의 useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  // 내부적으로 값을 기억하기 위한 mutable한 객체를 생성해주는 훅
+  // current값을 바꿔도 리렌더리이 되지않아야함
+  // setState를 호출하지 않아서 리렌더링 X
+  const [ref] = useState(() => ({ current: initialValue }));
+  return ref;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,7 +195,7 @@ export const ComplexForm: React.FC = memo(() => {
       e.preventDefault();
       addNotification("폼이 성공적으로 제출되었습니다", "success");
     },
-    [formData, addNotification],
+    [addNotification],
   );
 
   const handleInputChange = useCallback(
@@ -280,15 +280,14 @@ export const NotificationSystem: React.FC = memo(() => {
       {notifications.map((notification) => (
         <div
           key={notification.id}
-          className={`p-4 rounded shadow-lg ${
-            notification.type === "success"
-              ? "bg-green-500"
-              : notification.type === "error"
-                ? "bg-red-500"
-                : notification.type === "warning"
-                  ? "bg-yellow-500"
-                  : "bg-blue-500"
-          } text-white`}
+          className={`p-4 rounded shadow-lg ${notification.type === "success"
+            ? "bg-green-500"
+            : notification.type === "error"
+              ? "bg-red-500"
+              : notification.type === "warning"
+                ? "bg-yellow-500"
+                : "bg-blue-500"
+            } text-white`}
         >
           {notification.message}
           <button
@@ -326,11 +325,13 @@ const App: React.FC = () => {
   const login = useCallback((email: string) => {
     setUser({ id: 1, name: "홍길동", email });
     addNotification("성공적으로 로그인되었습니다", "success");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const logout = useCallback(() => {
     setUser(null);
     addNotification("로그아웃되었습니다", "info");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const addNotification = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, createContext, useContext } from "react";
+import { useMemo, useCallback, useDeepMemo, memo } from "./@lib";
 import { generateItems, renderLog } from "./utils";
 
 // 타입 정의
@@ -21,38 +22,62 @@ interface Notification {
   type: "info" | "success" | "warning" | "error";
 }
 
-// AppContext 타입 정의
-interface AppContextType {
+interface ThemeContextType {
   theme: string;
   toggleTheme: () => void;
+}
+
+interface UserContextType {
   user: User | null;
   login: (email: string, password: string) => void;
   logout: () => void;
+}
+
+interface NotificationContextType {
   notifications: Notification[];
   addNotification: (message: string, type: Notification["type"]) => void;
   removeNotification: (id: number) => void;
 }
 
-const AppContext = createContext<AppContextType | undefined>(undefined);
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+const UserContext = createContext<UserContextType | undefined>(undefined);
+const NotificationContext = createContext<NotificationContextType | undefined>(
+  undefined,
+);
 
-// 커스텀 훅: useAppContext
-const useAppContext = () => {
-  const context = useContext(AppContext);
+const useThemeContext = () => {
+  const context = useContext(ThemeContext);
   if (context === undefined) {
-    throw new Error("useAppContext must be used within an AppProvider");
+    throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+};
+const useUserContext = () => {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useUserContext must be used within a UserProvider");
+  }
+  return context;
+};
+const useNotificationContext = () => {
+  const context = useContext(NotificationContext);
+  if (context === undefined) {
+    throw new Error(
+      "useNotificationContext must be used within a NotificationProvider",
+    );
   }
   return context;
 };
 
 // Header 컴포넌트
-export const Header: React.FC = () => {
+export const Header: React.FC = memo(() => {
   renderLog("Header rendered");
-  const { theme, toggleTheme, user, login, logout } = useAppContext();
+  const { theme, toggleTheme } = useThemeContext();
+  const { user, login, logout } = useUserContext();
 
-  const handleLogin = () => {
-    // 실제 애플리케이션에서는 사용자 입력을 받아야 합니다.
+  const handleLogin = useCallback(() => {
     login("user@example.com", "password");
-  };
+  }, [login]);
 
   return (
     <header className="bg-gray-800 text-white p-4">
@@ -87,26 +112,32 @@ export const Header: React.FC = () => {
       </div>
     </header>
   );
-};
+});
 
 // ItemList 컴포넌트
 export const ItemList: React.FC<{
   items: Item[];
   onAddItemsClick: () => void;
-}> = ({ items, onAddItemsClick }) => {
+}> = memo(({ items, onAddItemsClick }) => {
   renderLog("ItemList rendered");
   const [filter, setFilter] = useState("");
-  const { theme } = useAppContext();
+  const { theme } = useThemeContext();
 
-  const filteredItems = items.filter(
-    (item) =>
-      item.name.toLowerCase().includes(filter.toLowerCase()) ||
-      item.category.toLowerCase().includes(filter.toLowerCase()),
-  );
+  const filteredItems = useDeepMemo(() => {
+    return items.filter(
+      (item) =>
+        item.name.toLowerCase().includes(filter.toLowerCase()) ||
+        item.category.toLowerCase().includes(filter.toLowerCase()),
+    );
+  }, [items, filter]);
 
-  const totalPrice = filteredItems.reduce((sum, item) => sum + item.price, 0);
+  const totalPrice = useDeepMemo(() => {
+    return filteredItems.reduce((sum, item) => sum + item.price, 0);
+  }, [filteredItems]);
 
-  const averagePrice = Math.round(totalPrice / filteredItems.length) || 0;
+  const averagePrice = useDeepMemo(() => {
+    return Math.round(totalPrice / filteredItems.length) || 0;
+  }, [totalPrice, filteredItems.length]);
 
   return (
     <div className="mt-8">
@@ -146,12 +177,12 @@ export const ItemList: React.FC<{
       </ul>
     </div>
   );
-};
+});
 
 // ComplexForm 컴포넌트
-export const ComplexForm: React.FC = () => {
+export const ComplexForm: React.FC = memo(() => {
   renderLog("ComplexForm rendered");
-  const { addNotification } = useAppContext();
+  const { addNotification } = useNotificationContext();
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -159,27 +190,33 @@ export const ComplexForm: React.FC = () => {
     preferences: [] as string[],
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    addNotification("폼이 성공적으로 제출되었습니다", "success");
-  };
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      addNotification("폼이 성공적으로 제출되었습니다", "success");
+    },
+    [formData, addNotification],
+  );
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: name === "age" ? parseInt(value) || 0 : value,
-    }));
-  };
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { name, value } = e.target;
+      setFormData((prev) => ({
+        ...prev,
+        [name]: name === "age" ? parseInt(value) || 0 : value,
+      }));
+    },
+    [],
+  );
 
-  const handlePreferenceChange = (preference: string) => {
+  const handlePreferenceChange = useCallback((preference: string) => {
     setFormData((prev) => ({
       ...prev,
       preferences: prev.preferences.includes(preference)
         ? prev.preferences.filter((p) => p !== preference)
         : [...prev.preferences, preference],
     }));
-  };
+  }, []);
 
   return (
     <div className="mt-8">
@@ -231,12 +268,12 @@ export const ComplexForm: React.FC = () => {
       </form>
     </div>
   );
-};
+});
 
 // NotificationSystem 컴포넌트
-export const NotificationSystem: React.FC = () => {
+export const NotificationSystem: React.FC = memo(() => {
   renderLog("NotificationSystem rendered");
-  const { notifications, removeNotification } = useAppContext();
+  const { notifications, removeNotification } = useNotificationContext();
 
   return (
     <div className="fixed bottom-4 right-4 space-y-2">
@@ -264,81 +301,94 @@ export const NotificationSystem: React.FC = () => {
       ))}
     </div>
   );
-};
+});
 
 // 메인 App 컴포넌트
 const App: React.FC = () => {
   const [theme, setTheme] = useState("light");
-  const [items, setItems] = useState(generateItems(1000));
   const [user, setUser] = useState<User | null>(null);
+  const [items, setItems] = useState(() => generateItems(1000));
+  // React는 초기값 함수를 매번 실행하지 않기때문에 직접 함수 호출 결과를 넘기면 초기 렌더링 외에도 매번 실행 된느것처럼 보일 수 있음
+  // 그래서, 함수 형태로 넘겨야함(초기 렌더링에만 실행)
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
-  const toggleTheme = () => {
+  const toggleTheme = useCallback(() => {
     setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
-  };
+  }, []);
 
-  const addItems = () => {
+  const addItems = useCallback(() => {
     setItems((prevItems) => [
       ...prevItems,
       ...generateItems(1000, prevItems.length),
     ]);
-  };
+  }, []);
 
-  const login = (email: string) => {
+  const login = useCallback((email: string) => {
     setUser({ id: 1, name: "홍길동", email });
     addNotification("성공적으로 로그인되었습니다", "success");
-  };
+  }, []);
 
-  const logout = () => {
+  const logout = useCallback(() => {
     setUser(null);
     addNotification("로그아웃되었습니다", "info");
-  };
+  }, []);
 
-  const addNotification = (message: string, type: Notification["type"]) => {
-    const newNotification: Notification = {
-      id: Date.now(),
-      message,
-      type,
-    };
-    setNotifications((prev) => [...prev, newNotification]);
-  };
+  const addNotification = useCallback(
+    (message: string, type: Notification["type"]) => {
+      const newNotification: Notification = {
+        id: Date.now(),
+        message,
+        type,
+      };
+      setNotifications((prev) => [...prev, newNotification]);
+    },
+    [],
+  );
 
-  const removeNotification = (id: number) => {
+  const removeNotification = useCallback((id: number) => {
     setNotifications((prev) =>
       prev.filter((notification) => notification.id !== id),
     );
-  };
+  }, []);
 
-  const contextValue: AppContextType = {
-    theme,
-    toggleTheme,
-    user,
-    login,
-    logout,
-    notifications,
-    addNotification,
-    removeNotification,
-  };
+  const themeValue = useMemo(
+    () => ({ theme, toggleTheme }),
+    [theme, toggleTheme],
+  );
+
+  const userValue = useMemo(
+    () => ({ user, login, logout }),
+    [user, login, logout],
+  );
+
+  const notificationValue = useMemo(
+    () => ({ notifications, addNotification, removeNotification }),
+    [notifications, addNotification, removeNotification],
+  );
 
   return (
-    <AppContext.Provider value={contextValue}>
-      <div
-        className={`min-h-screen ${theme === "light" ? "bg-gray-100" : "bg-gray-900 text-white"}`}
-      >
-        <Header />
-        <div className="container mx-auto px-4 py-8">
-          <div className="flex flex-col md:flex-row">
-            <div className="w-full md:w-1/2 md:pr-4">
-              <ItemList items={items} onAddItemsClick={addItems} />
+    <ThemeContext.Provider value={themeValue}>
+      <UserContext.Provider value={userValue}>
+        <NotificationContext.Provider value={notificationValue}>
+          <div
+            className={`min-h-screen ${theme === "light" ? "bg-gray-100" : "bg-gray-900 text-white"}`}
+          >
+            <Header />
+            <div className="container mx-auto px-4 py-8">
+              <div className="flex flex-col md:flex-row">
+                <div className="w-full md:w-1/2 md:pr-4">
+                  <ItemList items={items} onAddItemsClick={addItems} />
+                </div>
+                <div className="w-full md:w-1/2 md:pl-4">
+                  <ComplexForm />
+                </div>
+              </div>
             </div>
-            <div className="w-full md:w-1/2 md:pl-4">
-              <ComplexForm />
-            </div>
+            <NotificationSystem />
           </div>
-        </div>
-        <NotificationSystem />
-      </div>
-    </AppContext.Provider>
+        </NotificationContext.Provider>
+      </UserContext.Provider>
+    </ThemeContext.Provider>
   );
 };
 


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크
[https://choiseoeun-goup.github.io/front_5th_chapter1-3/](url)

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-5th-chapter1-1/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료
- [x] memo 구현 완료
- [x] deepMemo 구현 완료
- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useCallback 구현 완료

### 심화 과제

- [x] 기본과제에서 작성한 hook을 이용하여 렌더링 최적화를 진행하였다.
- [x] Context 코드를 개선하여 렌더링을 최소화하였다.

## 과제 셀프회고

회사에서는 Vue를 주로 사용하고 있어서 React의 Hook 개념이 다소 생소하게 느껴졌습니다. (사실 TypeScript도 처음이라... ㅎㅎ)

이번 과제를 통해 React의 렌더링 흐름을 공부하면서 Vue와 비교해보며 학습했고, 평소 개발할 때는 놓치기 쉬운 성능 최적화에 대해 다시 한번 생각해보는 계기가 되었습니다.

 `useCallback`, `useMemo` 등의 Hook을 실제 코드에 어떻게 적용할 수 있는지 직접 체험할 수 있었습니다. 단순히 "메모이제이션 = 성능 최적화"라고 알고 있던 개념에서 벗어나, **언제**, **왜**, **어떻게** 사용해야 하는지를 체감할 수 있었습니다.

특히 렌더링 최적화 전후의 차이를 눈으로 확인하면서 이해가 훨씬 잘 되었고, 의존성 배열을 잘못 설정했을 때 오히려 성능이 나빠질 수 있다는 점도 배울 수 있었습니다.

---

### Hook을 직접 구현하며 알게 된 렌더링 최적화의 본질

1. 불필요한 리렌더링 방지의 본질
    - 기존에는 useCallBack, useMemo를 써야 하니까 쓰는 것 처럼 사용했다면 과제를 진행하면서 내부적으로는 결국 이전 값과 현재 값을 비교해서 바뀌지 않으면 참조했던 걸 유지하는 방식이라는 걸 깨달았습니다.
    - 의존성 배열이 정확하지 않으면 오히려 성능이 나빠지는 것도 알게 되었습니다.
2. 참조 값의 변화와 렌더링의 관계
    - 리렌더링을 일으키는 조건이 값의 변화가 아니라 참조 값의 변화라는 걸 느꼇습니다.
    - 객체나 배열을 넘길 때는 내부 값이 같아도 새로 생성되면 렌더링이 트리거되기 때문에 깊은 비교가 필요하다고 이해했습니다.
3. Hook의 재 사용성과 커스텀 Hook에서의 캡슐화
    - Custom Hook자체가 React의 Hook기능을 재 사용한 가능한 로직으로 캡슐화한 함수로 여기서의 캡슐화는 내부 로직을 숨기고, 외부에는 인터페이스만 제공하는 것임을 알게 되었습니다.
    - 내부의 복잡한 로직을 감추고 재 사용할 수 있는 것이 커스텀 훅의 가장 큰 장점인 것 같습니다.

---

### **성능 최적화 관점에서의 과제 문제점 분석**

단순히 useCallBack,useMemo를 **쓴다**가 아니라 **왜,어디서,어떻게** 써야 의미가 있을까 고민해보았습니다.

1. 렌더링 빈도 확인
    - 문제
        - `Header`, `ItemList`, `ComplexForm`, `NotificationSystem`이 모두 매 렌더링마다 재 렌더링됨
        - 특히, `ItemList`는 items 가 1000개 이상임에도 필터링 혹은 리스트 추가 시 렌더링이 매번 발생
    - 개선 포인트
        - props 또는 Context 값이 바뀌지 않으면 재 렌더링 되지 않게 메모이제이션 필요
        - 컴포넌트를 React.memo로 감싸기
2. 불필요한 계산
    - 문제
        - ItemList에서 filteredItems, totalPrice, avaragePrice는 매 렌더링마자 재 계산됨.
        - filteredItems의 길이가 바뀌면서 다른 계산식도 계속 다시 돔 → 비용이 커짐
    - 개선 포인트
        - 연산 비용이 큰 함수의 결과값을 기억해두는 리액트 훅인 `useMemo`로 메모이제이션 처리
            
            ```jsx
            const filteredItems = useMemo(() => {
              return items.filter(...);
            }, [items, filter]);
            
            const totalPrice = useMemo(() => {
              return filteredItems.reduce(...);
            }, [filteredItems]);
            
            const averagePrice = useMemo(() => {
              return ...;
            }, [totalPrice, filteredItems.length]);
            
            ```
            
3. context의 구조
    - 문제
        - App에서 items, theme, user, notifications를 직접 useState로 관리하고 context에 넣음
        - AppContext에 너무 많은 값이 들어있고 theme, user, notification은 서로 독립적인 값임에도 한 context안에 묶여있어서 서로 연쇄적으로 렌더링이 발생함
    - 개선 포인트
        - `AppContext`를 `ThemeContext` , `UserContext` , `NotificationContext`로 나누기
4. useState의 함수형 초기 값 누락
    - 문제
        - `useState(generateItems`) 형태로 초기 값을 설정했으나, `geneateItmes`가 함수 형태로 전달 되지 않아 **컴포넌트가 재 렌더링 될 때마다 `generateItems()`가 실행**됨. 이로 인해 불필요하게 6번 호출
    - 개선 포인트
        - `useState(() => generateItems())` 형태로 수정하여 **초기 렌더링 시 딱 한 번만 `generateItems`가 실행되도록 개선**함.
        - lazy initialization의 개념을 알게됨

### Vue를 통해 React이해하기

회사에서는 Vue를 주로 사용하기 때문에, React를 공부하면서 Vue의 어떤 기능과 비슷한지 비교하며 학습했습니다. React의 성능 최적화 기법들이 Vue에서도 어떻게 적용될 수 있을지 고민해보며, 두 프레임워크 간 개념을 연결하여 React를 더 이해해보려 했습니다.

그래서 이번 과제인 성능 최적화와 관련된 useCallback, useMemo, useRef,useDeepMemo를 중심으로 Vue와의 차이를 분석해 보았습니다.

1. Vue의 `method`, `setup` 함수 내부 함수 선언과 React 의 `useCallback`
    - React : useCallback은 함수가 불필요하게 재 생성되는 것을 방지하여 자식 컴포넌트가 불필요하게 리렌더링되지 않도록 해줍니다.
    - Vue : Vue에서는 methods안에 함수를 정의하거나 <script setup>내부에서 선언하는데, 함수는 컴포넌트가 다시 렌더링되더라도 재 정의 되지 않습니다. React처럼 의존성 배열을 따로 관리할 필요가 없어 상대적으로 간편합니다.
2. Vue의 `computed` 와 React의  `useMemo`
    - React : useMemo는 값의 계산 결과를 메모이징하여 성능을 최적화합니다.
    - Vue : computed 속성은 React의 useMemo와 유사하게 작동하는 것 같습니다. 값이 변경되지 않으면 이전에 저장된 값을 재 사용합니다.
3.  Vue의 `template ref` or `reactive ref` 와 React의 `useRef`
    - React : useRef는 DOM에 직접 접근하거나 변경 가능한 값을 저장하는데 사용합니다. 리렌더링없이 값을 유지할 수 있습니다.
    - Vue : template ref는 DOM요소에 직접 접근할 때 사용합니다. 리렌더링과 직접적인 관련은 없고 단순히 DOM이나 컴포넌트를 직접 참조하기 위한 수단입니다. 하지만 reactive ref는 리렌더링과 관련이 있습니다. 값이 변경되면 템플릿 영역만 다시 렌더링 됩니다.
4. Vue의 `watch` 와 React의 `useDeepMemo`
    - React : uesDeepMemo는 객체나 배열처럼 참조형의 값의 변경을 깊게 비교해서 불필요한 재 계산을 막습니다.
    - Vue : 기본적으로 computed가 얕은 비교, watch를 deep옵션을 통하여 깊은 비교를 할 때 사용합니다.

이런 비교를 통해서 React는 성능 최적화를 위해 개발자가 직접 관리해야 할 부분이 많은데 Vue는 자동으로 처리되는게 많다는 것을 알 수 있었습니다.

### 과제 셀프 피드백

- App 파일 하나에 너무 많은 것이 들어있어서 이를 기능 별로 파일을 분리하고 역할을 나누는 구조적인 설계를 도입하고 싶었는데 시간 관계 상 못해서 아쉬운 것 같습니다.
- 추후에 아래와 같이 구조를 변경해서 리팩토링을 진행하고 싶습니다.
    
    ```css
    src/
    ├── components/
    │   ├── Header.tsx
    │   ├── ItemList.tsx
    │   ├── ComplexForm.tsx
    │   └── NotificationSystem.tsx
    │
    ├── contexts/
    │   ├── ThemeContext.tsx
    │   ├── UserContext.tsx
    │   └── NotificationContext.tsx
    │
    ├── hooks/
    │   ├── useThemeContext.ts
    │   ├── useUserContext.ts
    │   └── useNotificationContext.ts
    │
    ├── utils/
    │   ├── generateItems.ts
    │   └── renderLog.ts
    │
    └── App.tsx
    ```
    
- 컴포넌트의 책임을 분리하고, Context 단위로 관리하는 구조를 만들면 훨씬 확장성과 유지보수성이 좋아질 것 같습니다.

### **리뷰 받고 싶은 내용**

- React.memo를 불필요하게 쓰면 안될 것 같은데 어디까지 써야하는지 언제 써야하는지 잘 개념정리가 안되는거 같아요! 팁이 있으실까요?

